### PR TITLE
Add gh action workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,41 @@
+name: github pages
+
+on:
+  push:
+    branches:
+      - main  # Set a branch to deploy
+  pull_request:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    steps:
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+
+      - run: gem install asciidoctor
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Build
+        run: |
+          alias asciidoctor="asciidoctor --attribute=experimental=true --attribute=icons=font"
+          hugo --minify
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL: "http://localhost:1313/"
+baseURL: "https://docs-ng.hybrid-cloud-patterns.io"
 languageCode: "en-us"
 title: Hybrid Cloud Patterns
 theme: "patternfly"

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+docs-ng.hybrid-cloud-patterns.io


### PR DESCRIPTION
This workflow builds the website with extended hugo + asciidoctor from
the main branch of the repo.
It then publishes everything in the 'gh-pages' branch.

So the GH Pages settings need to be configured as follows:
1. Deploy from a branch -> Choose gh-pages
2. Custom domain docs-ng.hybrid-cloud-patterns.io
