### PR TITLE
Added current repo structure and add IDs for all headings

### DIFF
--- a/content/contribute/contribute-to-docs.adoc
+++ b/content/contribute/contribute-to-docs.adoc
@@ -7,8 +7,10 @@ weight: 60
 
 :toc:
 
+:_content-type: ASSEMBLY
+
 Use the Contributor's guide to learn about ways to contribute to the Hybrid Cloud Patterns, to understand the prerequisites and toolchain required for contribution, and to follow some basic documentation style and structure guidelines.
 
 include::modules/contributing.adoc[leveloffset=+1]
-include::modules/tools_and_setup.adoc[leveloffset=+1]
-include::modules/doc_guidelines.adoc[leveloffset=+1]
+include::modules/tools-and-setup.adoc[leveloffset=+1]
+include::modules/doc-guidelines.adoc[leveloffset=+1]

--- a/modules/contributing.adoc
+++ b/modules/contributing.adoc
@@ -1,47 +1,54 @@
+:_content-type: CONCEPT
 [id="contributing-to-docs-contributing"]
 = Contribute to Hybrid Cloud Patterns documentation
 :icons:
 :description: Contribute to Hybrid Cloud Patterns documentation
 :imagesdir: ../images
 
-
+[id="different-ways-to-contribute"]
 == Different ways to contribute
 
 There are a few different ways you can contribute to Hybrid Cloud Patterns documentation:
 
-* Email the Hybrid Cloud Patterns team at `<>@redhat.com`.
+* Email the Hybrid Cloud Patterns team at `hybrid-cloud-patterns@googlegroups.com`.
 * Create a link:https://github.com/hybrid-cloud-patterns/docs/issues[GitHub] or link:https://issues.redhat.com/projects/MBP/issues[Jira issue] .
 //to-do: Add link to the contribution workflow when we have a proper one. You might need to create a new file
 * Submit a pull request (PR). To create a PR, create a local clone of your own fork of the link:https://github.com/hybrid-cloud-patterns/docs[Hybrid Cloud Patterns docs repository], make your changes, and submit a PR. This option is best if you have substantial changes. For more details on creating a PR see <topic_link_to_contribution_workflow>.
 
+[id="contribution-workflow"]
 == Contribution workflow
-// to-do:Create a docs team: https://github.com/orgs/hybrid-cloud-patterns/teams
+
 When you submit a PR, the https://github.com/orgs/hybrid-cloud-patterns/teams/docs[Hybrid Cloud Patterns Docs team] reviews the PR and arranges further reviews by Quality Engineering (QE), subject matter experts (SMEs), and others, as required. If the PR requires changes, updates, or corrections, the reviewers add comments in the PR. The documentation team merges the PR after you have implemented all feedback, and you have squashed all commits.
 
-
+[id='repository-organization']
 == Repository organization
 
-//to-do:Placeholder to explain how assemblies, modules, images, common/attribute folders are organized.
+The `content` and the `modules` directory are the primary directories for developing teh Hybrid Cloud Patterns content. The publishing toolchain uses Hugo, the configuration for which is defined in the `config.yaml` file.
 
 ----
-├── assemblies
-│   └── multicloud-gitops-architecture.adoc
+├── archetypes
+├── content
+│   └── blog
+|   └── contribute
+|   └── learn
+|   |  └── multicloud-gitops
+|   |  | └──multicloud-gitops-assembly.adoc
+|   |  └── medical-diagnosis
+|   |    └── medical-diagnosis-assembly.adoc
+|   └── patterns
+├── images
+├── layouts
 ├── modules
 │   └── multicloud-gitops-logical-architecture.adoc
 │   └── multicloud-gitops-physical-architecture.adoc
-├── common-attributes
-│   └── common_attributes.adoc
-├── snippets
-│   └── common-snippets.adoc
-├── images
-│    └── hybrid-multicloud-management-gitops-hl-arch.png
+├── common-docs
+│   └── attributes.adoc
+├── static
+├── themes
+├── config.yaml
 └── README.adoc
-
 ----
-
+[role="_next-steps"]
 == Next steps
-* link:tools_and_setup.adoc[Install and set up the tools and software]
-on your workstation so that you can contribute.
-* link:doc_guidelines.adoc[Review the documentation guidelines] to
-understand some basic guidelines to keep things consistent
-across our content.
+* link:tools_and_setup.adoc[Install and set up the tools and software] on your workstation so that you can contribute.
+* link:doc_guidelines.adoc[Review the documentation guidelines] to understand some basic guidelines to keep things consistent across our content.

--- a/modules/doc-guidelines.adoc
+++ b/modules/doc-guidelines.adoc
@@ -1,9 +1,11 @@
+:_content-type: CONCEPT
 [id="contributing-to-docs-doc-guidelines"]
 = Documentation guidelines
 
 :description: Documentation guidelines for contributing to the Hybrid Cloud Patterns Docs
 :imagesdir: ../images
 
+[id="general-guidelines"]
 == General guidelines
 When authoring content, follow these style guides:
 
@@ -14,6 +16,7 @@ NOTE: When asked for an IBMid, Red Hat associates can use their Red Hat e-mail.
 * link:https://redhat-documentation.github.io/modular-docs/#writing-mod-docs[Modular documentation reference guide]
 ** link:https://github.com/redhat-documentation/modular-docs/tree/main/modular-docs-manual/files[Modular documentation templates]
 
+[id="modular-documentation-terms"]
 == Modular documentation terms
 
 [options="header"]
@@ -35,7 +38,7 @@ NOTE: When asked for an IBMid, Red Hat associates can use their Red Hat e-mail.
 
 |===
 
-
+[id="naming-conventions-for-assembly-module-files]
 == Naming conventions for assembly and module files
 Use lowercase separated by dash. Create assembly and module file names that accurately and closely reflect the title of the assembly or module.
 
@@ -45,6 +48,7 @@ Use lowercase separated by dash. Create assembly and module file names that accu
 * `creating-guided-decision-tables.adoc`` (Procedure module for creating)
 * `guided-decision-table-examples.adoc` (Reference module with examples)
 
+[id="content-type-attributes"]
 === Content type attributes
 
 Each `.adoc` file must contain a `:_content-type:` attribute in its metadata that indicates its file type. This information is used by some publication processes to sort and label files.
@@ -58,11 +62,14 @@ Add the attribute from the following list that corresponds to your file type:
 
 See, xref:doc_guidelines.adoc#assembly-file-metadata[Assembly file metadata] and xref:doc_guidelines.adoc#module-file-metadata[Module file metadata].
 
+[id="naming-conventions-for-directories"]
 == Naming conventions for directories
 
 Use lowercase. For directory with a multiple-word name, use lowercase separated by dash, for example `multicloud-gitops`.
 
+[id="language-and-grammar"]
 == Language and grammar
+
 Consider the following guidelines:
 * Use present tense.
 * Use active voice.
@@ -72,7 +79,9 @@ Consider the following guidelines:
 * Use the appropriate tone.
 * Write for a global audience.
 
+[id="titles-and-headings"]
 == Titles and headings
+
 Use sentence-style capitalization in all titles and section headings. Ensure that titles focus on customer tasks instead of the product.
 
 For assemblies and procedure modules, use a gerund form in headings, such as:
@@ -98,7 +107,7 @@ For modules that do not include any procedure, use a noun phrase, for example _R
 //[id="managing-authorization-policies_{context}"]
 //== Managing authorization policies
 //----
-
+[id="writing-assemblies"]
 == Writing assemblies
 
 For more information about forming assemblies, see the
@@ -128,7 +137,7 @@ include::_common-docs/common-attributes.adoc[]                   <4>
 
 After the heading block and a single whitespace line, you can include any content for this assembly.
 
-
+[id="writing-modules"]
 == Writing modules
 For more information about creating modules, see the https://redhat-documentation.github.io/modular-docs/#_creating_modules[Red Hat Modular documentation reference guide].
 
@@ -187,6 +196,7 @@ rh-rhacm-product: Red Hat Advanced Cluster Management (RHACM)
 
 For more information on attributes, see link: https://docs.asciidoctor.org/asciidoc/latest/key-concepts/#attributes.
 
+[id="formatting"]
 == Formatting
 Use the following links to refer to AsciiDoc markup and syntax.
 
@@ -196,6 +206,7 @@ Use the following links to refer to AsciiDoc markup and syntax.
 
 If you are graduating to AsciiDoc from Markdown, see the https://docs.asciidoctor.org/asciidoc/latest/asciidoc-vs-markdown/#comparison-by-example[AsciiDoc to Markdown syntax comparison by example].
 
+[id="formatting-commands-code-blocks"]
 === Formatting commands and code blocks
 To enable syntax highlighting, use `[source,terminal]` for any terminal commands, such as `oc` commands and their outputs. For example:
 ....

--- a/modules/tools-and-setup.adoc
+++ b/modules/tools-and-setup.adoc
@@ -1,14 +1,16 @@
+:_content-type: CONCEPT
 [id="contributing-to-docs-tools-and-setup"]
 = Install and set up the tools and software
 :icons:
 :linkattrs:
 :description: How to set up and install the tools to contribute
 
-
+[id="create-github-account"]
 == Create a GitHub account
 Before you can contribute to Hybrid Cloud Patterns documentation, you must
 https://www.github.com/join[sign up for a GitHub account].
 
+[id="set-up-authentication"]
 == Set up authentication
 When you have your account set up, follow the instructions to
 https://help.github.com/articles/generating-ssh-keys/[generate and set up SSH
@@ -19,7 +21,7 @@ Confirm authentication is working correctly with the following command:
 ----
 $ ssh -T git@github.com
 ----
-
+[id="fork-and-clone-docs-repo"]
 == Fork and clone the Hybrid Cloud Patterns documentation repository
 You must fork and set up the Hybrid Cloud Patterns documentation repository on your workstation so that you can create PRs and contribute. These steps must only be performed during initial setup.
 
@@ -52,10 +54,14 @@ $ git remote add upstream git@github.com:hybrid-cloud-patterns/docs.git
 This ensures that you are tracking the remote repository to keep your local
 repository in sync with it.
 
+[id="install-asciidoctor"]
 == Install Asciidoctor
+
 The Hybrid Cloud Patterns documentation is created in AsciiDoc language, and is processed with http://asciidoctor.org/[AsciiDoctor], which is an AsciiDoc language processor.
 
+[id="prerequisites"]
 === Prerequisites
+
 The following are minimum requirements:
 
 * A bash shell environment (Linux and OS X include a bash shell environment)


### PR DESCRIPTION
This PR updates the following:

- Adds details about the current repo structure and add IDs for all headings (might need them for linking). 
- Renames `doc_guidelines.adoc -> doc-guidelines.adoc` and `tools_and_setup.adoc -> tools-and-setup.adoc` to adhere to the Contributor's guide (use dash instead of underscore)
- Adds content type metadata to all file types.